### PR TITLE
[feat:#4] Generals, Scrpas 테이블 추가, Users, Posts 테이블 수정

### DIFF
--- a/src/main/java/bokzip/back/domain/General.java
+++ b/src/main/java/bokzip/back/domain/General.java
@@ -1,0 +1,31 @@
+package bokzip.back.domain;
+
+import lombok.Data;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "Generals")
+@Data
+public class General {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="general_id")
+    private Long id;
+
+    //7가지 분야(건강/의료, 문화, 보육 등)
+    @Column()
+    private String category;
+
+    //제목
+    @Column()
+    private String title;
+
+    //내용
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    //이미지
+    @Column(columnDefinition = "TEXT")
+    private String image;
+}

--- a/src/main/java/bokzip/back/domain/PersonalInfo.java
+++ b/src/main/java/bokzip/back/domain/PersonalInfo.java
@@ -1,63 +1,28 @@
-package bokzip.back.domain;
-
-import javax.persistence.*;
-import java.util.List;
-
-@Entity
-@Table(name = "Personal_info")
-public class PersonalInfo {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // @brief : PK, auto_increment
-    private Long pid; // @param : personal_info id
-
-    @OneToMany(mappedBy = "uid") // 1:n //@TODO : users 테이블 기준으로 1:n
-//    @JoinColumn(name = "uid_fk")  //오류나서 주석처리
-    private List<User> uid; // @brief : users 테이블의 uid (fk)
-
-    @Column(length = 64)
-    private String situation; // @param : 상황(장애, 임신, 한부모 등)에 해당하는 변수 // @TODO : 변수명 변경 필요
-
-    // @TODO : 거주지 추가
-
-    @Column(length = 128)
-    private String topic; // @param : 관심주제
-
-    //@brief : 필드의 getter, setter
-    public Long getPid() {
-        return pid;
-    }
-
-    public void setPid(Long pid) {
-        this.pid = pid;
-    }
-
-    public List<User> getUid() {
-        return uid;
-    }
-
-    public void setUid(List<User> uid) {
-        this.uid = uid;
-    }
-
-    public String getSituation() {
-        return situation;
-    }
-
-    public void setSituation(String situation) {
-        this.situation = situation;
-    }
-
-    public String getTopic() {
-        return topic;
-    }
-
-    public void setTopic(String topic) {
-        this.topic = topic;
-    }
-
-    @Override
-    public String toString() {
-        return super.toString();
-    }
-}
+//package bokzip.back.domain;
+//
+//import lombok.Data;
+//
+//import javax.persistence.*;
+//import java.util.List;
+//
+// @TODO : 해당 코드는 나중에 확실하게 사용안하는 것으로 확인되면 삭제하겠습니다.
+//
+//@Entity
+//@Data
+//@Table(name = "Personal_info")
+//public class PersonalInfo {
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long personal_id;
+//
+//    @OneToMany(mappedBy = "uid") // 1:n //@TODO : users 테이블 기준으로 1:n
+//    private List<User> user_id;
+//
+//    //거주지 정보
+//    @Column
+//    private String address;
+//
+//    //관심주제
+//    @Column(length = 128)
+//    private String topic;
+//}

--- a/src/main/java/bokzip/back/domain/Post.java
+++ b/src/main/java/bokzip/back/domain/Post.java
@@ -13,6 +13,7 @@ import java.util.Date;
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="post_id")
     private Long id;
 
     @Column()

--- a/src/main/java/bokzip/back/domain/Scrap.java
+++ b/src/main/java/bokzip/back/domain/Scrap.java
@@ -1,0 +1,29 @@
+package bokzip.back.domain;
+
+import lombok.Data;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "Scraps")
+@Data
+public class Scrap{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="scrap_id")
+    private Long id;
+
+    /**
+     * @see : scarp은 user_id와 post_id를 통해 users, posts를 조회할 수 있지만,
+     *        posts, users에는 scarp_id가 없음 -> 단방향 관계(@ManyToOne)
+     *        scrap(1) : users(n) / posts(n)
+     */
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/bokzip/back/domain/User.java
+++ b/src/main/java/bokzip/back/domain/User.java
@@ -1,104 +1,36 @@
 package bokzip.back.domain;
 
+import lombok.Data;
+
 import javax.persistence.*;
 
 @Entity
 @Table(name = "Users")
+@Data
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // @brief : PK, auto_increment
-    private Long uid; // @param : user id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_id")
+    private Long id;
 
-    @OneToOne // 1:1
-    @JoinColumn(name = "pid_fk") // @param : personal_info id (fk)
-    private PersonalInfo pid; //
-
-    // @brief : @Column 매핑을 생략하면 필드명을 사용해서 매핑. 필드명과 데이터필드명을 동일하게 설정하여 명시적 매핑 X
-
+    // 소셜 로그인 email
     @Column(nullable = false)
-    private String email; // @param : 소셜 로그인 email
+    private String email;
 
+    //소셜로그인 이름
     @Column(nullable = false)
-    private String passwd; // @param : 소셜 로그인 pw // @TODO : OAuth 인증 db 찾아보고 수정 필요 없애던가 말던가
+    private String name;
 
+    //소셜로그인 프로필사진
     @Column(nullable = false)
-    private String name; // @param : 소셜로그인 이름
+    private String profile;
 
-    @Column(nullable = false)
-    private String profile; // @param : 소셜로그인 프로필사진
+    //거주지 정보
+    @Column
+    private String address;
 
-    private String access_token; // @param : JWT 액세스 토큰 // @TODO : 회의 후 db에 보관할지(서버사이드), 세션에 저장할지
-
-    private String refresh_token; // @param : JWT 리프레시 토큰  // @TODO : 회의 후 db에 보관할지(서버사이드), 세션에 저장할지
-
-    // @brief : 각 필드의 getter, setter
-    public Long getUid() {
-        return uid;
-    }
-
-    public void setUid(Long uid) {
-        this.uid = uid;
-    }
-
-    public PersonalInfo getPid() {
-        return pid;
-    }
-
-    public void setPid(PersonalInfo pid) {
-        this.pid = pid;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPasswd() {
-        return passwd;
-    }
-
-    public void setPasswd(String passwd) {
-        this.passwd = passwd;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getProfile() {
-        return profile;
-    }
-
-    public void setProfile(String profile) {
-        this.profile = profile;
-    }
-
-    public String getAccess_token() {
-        return access_token;
-    }
-
-    public void setAccess_token(String access_token) {
-        this.access_token = access_token;
-    }
-
-    public String getRefresh_token() {
-        return refresh_token;
-    }
-
-    public void setRefresh_token(String refresh_token) {
-        this.refresh_token = refresh_token;
-    }
-
-    @Override
-    public String toString() {
-        return super.toString();
-    }
+    //관심주제
+    @Column(length = 128)
+    private String category;
 }


### PR DESCRIPTION
1. 일반 탭에 사용될 (generals 테이블) 생성 //`General.java`
2. 스크랩 탭에 사용될 (scraps 테이블) 생성 //`Scraps.java`
3. PersonalInfo.java에 있던 칼럼 -> users 테이블로 옮겼습니다. //`Users.java`
  - 해당 파일은 나중에 확실하게 사용 안되는 걸로 확인되면 지우겠습니다!
4. 스크랩 테이블에 post와 user의 id 값으로 외래키를 지정하면서 posts 테이블의 id 칼럼명을 post_id로 변경하였습니다.

----
heroku에 있는 db에도 테이블을 생성했으며 generals 테이블에 엑셀 데이터 추가하였습니다.