### PR TITLE
[feat:#26] 필터구현 및 조회수 증가 관련

### DIFF
--- a/src/main/java/bokzip/back/controller/GeneralController.java
+++ b/src/main/java/bokzip/back/controller/GeneralController.java
@@ -2,10 +2,12 @@ package bokzip.back.controller;
 
 import bokzip.back.domain.General;
 import bokzip.back.dto.GeneralMapping;
-import bokzip.back.dto.HomeMapping;
-import bokzip.back.dto.ScrapMapping;
 import bokzip.back.service.GeneralService;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +51,12 @@ public class GeneralController {
             throw new RuntimeException("404");
 
         return general;
+    }
+
+    //@param : 일반 조회수 증가
+    @GetMapping("/general/view/{id}")
+    public void addGeneralView(@PathVariable @Validated Long id) {
+        generalService.addGeneralView(id);
     }
 
 }

--- a/src/main/java/bokzip/back/controller/PostController.java
+++ b/src/main/java/bokzip/back/controller/PostController.java
@@ -1,19 +1,19 @@
 package bokzip.back.controller;
 
 import bokzip.back.domain.Post;
-import bokzip.back.dto.HomeMapping;
+import bokzip.back.dto.PostMapping;
+import bokzip.back.dto.SortType;
 import bokzip.back.service.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @RequestMapping("/post")
 @RestController
-public class PostController{
+public class PostController {
 
     private final PostService postService;
 
@@ -23,32 +23,35 @@ public class PostController{
     }
 
     //@param : [중앙부처 + 로컬] 전체 데이터 조회
-    @GetMapping("/center")
-    public List<HomeMapping> selectAll(){
-        return postService.findAll();}
+    @GetMapping("/centers")
+    public List<PostMapping> selectAll() {
+        return postService.findAll();
+    }
+
 
     //@param : [중앙부처 + 로컬] pk로 데이터 조회
     @GetMapping("/center/{id}")
-    public Optional<Post> getOneData(@PathVariable @Validated Long id){ //id에 validated로 선언하여 binding error 시 에러 호출
+    public Optional<Post> addOneData(@PathVariable @Validated Long id) {
         Optional<Post> post = postService.findId(id);
 
-        if(!post.isPresent()) //null 값 반환 방지
+        if (!post.isPresent()) //null 값 반환 방지
             throw new RuntimeException("404");
 
         return post;
     }
 
-    //@param : [중앙부처] category로 조회
-    @GetMapping("/center/category/{category}")
-    public List<HomeMapping> getAllCategory(@PathVariable @Validated String category){
-        List<HomeMapping> categoryResult = new ArrayList<>();
-
-        postService.getListLikeCategory(category).forEach(categoryResult::add);
-
-        if(categoryResult.isEmpty()) //null 값 반환 방지
-            throw new RuntimeException("404");
-
-        return categoryResult;
+    //@param : [중앙부처 + 로컬] 조회수 증가
+    @GetMapping("/center/view/{id}")
+    public void addPostView(@PathVariable @Validated Long id) {
+        postService.addPostView(id);
     }
 
+    //@param : [중앙부처 + 로컬] 맞춤형 정보
+    @GetMapping("/center/custom")
+    public List<PostMapping> getPosts(@RequestParam(value = "category") String category,
+                                      @RequestParam(value = "local", required = false, defaultValue = "") String local,
+                                      @RequestParam(value = "sort", required = false, defaultValue = "") SortType sort
+    ) {
+        return postService.getListCategorySort(category, sort);
+    }
 }

--- a/src/main/java/bokzip/back/dto/SortType.java
+++ b/src/main/java/bokzip/back/dto/SortType.java
@@ -1,0 +1,6 @@
+package bokzip.back.dto;
+
+public enum SortType {
+    viewCount,
+    starCount
+}

--- a/src/main/java/bokzip/back/repository/PostRepository.java
+++ b/src/main/java/bokzip/back/repository/PostRepository.java
@@ -13,14 +13,21 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     // @param : 중앙부처 상황별 데이터 조회
-    /** @todo
+
+    /**
+     * @todo
      * @see : 우선 start_count를 보내도록 했음. user와 scrap 디비에 값을 넣은 후에는 join 결과를 보내도록 수정해야 할 듯
-     *        유저가 해당 아이템을 스크랩 했는지의 여부니까!
-     *        참고사이트 : https://velog.io/@devyu/spring-Spring-Data-JPA-%EA%B8%B0%EB%B3%B8%EC%A0%95%EB%A6%AC
-     *                   https://ppomelo.tistory.com/155?category=908484
+     * 유저가 해당 아이템을 스크랩 했는지의 여부니까!
+     * 참고사이트 : https://velog.io/@devyu/spring-Spring-Data-JPA-%EA%B8%B0%EB%B3%B8%EC%A0%95%EB%A6%AC
+     * https://ppomelo.tistory.com/155?category=908484
      */
 
-    List<HomeMapping> findByCategoryLike(@Param("category")String category);
+    List<PostMapping> findByCategoryLike(@Param("category") String category);
 
-    List<HomeMapping> findAllBy(Sort id);
+    List<PostMapping> findAllBy(Sort id);
+
+
+    List<PostMapping> findByCategoryContainsOrderByViewCountDesc(String category);
+
+    List<PostMapping> findByCategoryContainsOrderByStarCountDesc(String category);
 }

--- a/src/main/java/bokzip/back/service/GeneralService.java
+++ b/src/main/java/bokzip/back/service/GeneralService.java
@@ -37,4 +37,14 @@ public class GeneralService {
         return generalRepository.findAllBy(Sort.by(Sort.Direction.DESC, "viewCount"));
 
     }
+
+    public void addGeneralView(Long id) {
+        if (id >= 100 || id <= 0)
+            throw new RuntimeException("404");
+
+        Optional<General> general = generalRepository.findById(id);
+        Integer viewCount = general.get().getViewCount();
+        general.get().setViewCount(++viewCount);
+        generalRepository.save(general.get());
+    }
 }

--- a/src/main/java/bokzip/back/service/PostService.java
+++ b/src/main/java/bokzip/back/service/PostService.java
@@ -1,7 +1,8 @@
 package bokzip.back.service;
 
 import bokzip.back.domain.Post;
-import bokzip.back.dto.HomeMapping;
+import bokzip.back.dto.PostMapping;
+import bokzip.back.dto.SortType;
 import bokzip.back.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -17,36 +18,72 @@ public class PostService {
     private final PostRepository postRepository;
 
     @Autowired //DI
-    public PostService(PostRepository postRepository){
+    public PostService(PostRepository postRepository) {
         this.postRepository = postRepository;
     }
 
     // @param : [중앙부처 + 로컬] 데이터 PK로 조회
-    public Optional<Post> findId(Long id){
+    public Optional<Post> findId(Long id) {
         if (id >= 1000 || id <= 0) //id가 null인 경우 url == 전체 조회 url
             throw new RuntimeException("404");
+
+        Object nullCheck = id;
+        if (nullCheck == null)
+            throw new RuntimeException("400");
 
         return postRepository.findById(id);
     }
 
     // @param : [중앙부처 + 로컬] 모든 데이터 조회
-    public List<HomeMapping> findAll(){
+    public List<PostMapping> findAll() {
 //        return postRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
         return postRepository.findAllBy(Sort.by(Sort.Direction.ASC, "id"));
     }
 
     // @param : [중앙부처] 데이터 category로 조회
-    public List<HomeMapping> getListLikeCategory(String category){
+    public List<PostMapping> getListLikeCategory(String category) {
         String req_category = "%";
 
         boolean isNumber = category.matches("^[0-9]*$");
         boolean isEnglish = category.matches("^[a-zA-Z]*$");
 
-        if(isNumber || isEnglish)
+        if (isNumber || isEnglish)
             throw new RuntimeException("400");
 
         req_category += category;
 
         return postRepository.findByCategoryLike(req_category);
+    }
+
+    public void addPostView(Long id) {
+        if (id >= 1000 || id <= 0)
+            throw new RuntimeException("404");
+
+        Optional<Post> post = postRepository.findById(id);
+        Integer viewCount = post.get().getViewCount();
+        post.get().setViewCount(++viewCount);
+        postRepository.save(post.get());
+    }
+
+    public List<PostMapping> getListCategorySort(String category, SortType sort) {
+
+
+        boolean isNumber = category.matches("^[0-9]*$");
+        boolean isEnglish = category.matches("^[a-zA-Z]*$");
+
+        if (isNumber || isEnglish)
+            throw new RuntimeException("400");
+
+        if (category.equals("전체")) category = "지원";
+
+
+        switch (sort) {
+            case viewCount:
+                return postRepository.findByCategoryContainsOrderByViewCountDesc(category);
+            case starCount:
+                return postRepository.findByCategoryContainsOrderByStarCountDesc(category);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
### 필터 구현 
- category = 생활지원, 고용지원, 건강지원, 교육지원, 전체 
- sort = viewCount, starCount ( Enum Type으로 지정했기때문에 다른 값이 오면 에러남 유의) 
_**viewCount- 조회수 순 | starCount- 스크랩 순**_
- 현재 거주지 같은 경우는 데이터 정리가 필요하기 때문에 local= 혹은 아예 보내지 않아도 됨.
- 사진에서 post 21번이 viewCount가 제일 높으므로 먼저 나옴( 테스트 완료)
![image](https://user-images.githubusercontent.com/70589857/131774825-8560d0dd-0c65-4707-9ef1-5323bad09661.png)

### 조회 수 증가
일반, 중앙부처, 지역 데이터 API 요청 후 viewCount +1 증가
