### PR TITLE
[mod#26] local -> area 컬럼 변경

### DIFF
--- a/src/main/java/bokzip/back/controller/PostController.java
+++ b/src/main/java/bokzip/back/controller/PostController.java
@@ -66,10 +66,10 @@ public class PostController {
     //@param : [중앙부처 + 로컬] 맞춤형 정보
     @GetMapping("/center/custom")
     public List<PostMapping> getPosts(@RequestParam(value = "category") String category,
-                         @RequestParam(value = "local", required = false, defaultValue = "") String local,
-                         @RequestParam(value = "sort", required = false, defaultValue = "Id") SortType sort
+                                      @RequestParam(value = "area", required = false, defaultValue = "") String area,
+                                      @RequestParam(value = "sort", required = false, defaultValue = "Id") SortType sort
     ) {
 
-        return postService.getListCategorySort(category, sort);
+        return postService.getListCategorySort(category, area, sort);
     }
 }

--- a/src/main/java/bokzip/back/repository/PostRepository.java
+++ b/src/main/java/bokzip/back/repository/PostRepository.java
@@ -27,10 +27,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<PostMapping> findAllBy(Sort id);
 
 
-    List<PostMapping> findByCategoryContainsOrderByViewCountDesc(String category);
+    List<PostMapping> findByCategoryContainsAndAreaContainsOrderByViewCountDesc(String category, String area);
 
-    List<PostMapping> findByCategoryContainsOrderByStarCountDesc(String category);
+    List<PostMapping> findByCategoryContainsAndAreaContainsOrderByStarCountDesc(String category, String area);
 
-    List<PostMapping> findByCategoryContainsOrderByIdAsc(String category);
+    List<PostMapping> findByCategoryContainsAndAreaContainsOrderByIdAsc(String category, String area);
 
 }

--- a/src/main/java/bokzip/back/service/PostService.java
+++ b/src/main/java/bokzip/back/service/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
         postRepository.save(post.get());
     }
 
-    public List<PostMapping> getListCategorySort(String category, SortType sort) {
+    public List<PostMapping> getListCategorySort(String category, String area, SortType sort) {
 
 
         boolean isNumber = category.matches("^[0-9]*$");
@@ -81,14 +81,13 @@ public class PostService {
 
         if (category.equals("전체")) category = "지원";
 
-
         switch (sort) {
             case viewCount:
-                return postRepository.findByCategoryContainsOrderByViewCountDesc(category);
+                return postRepository.findByCategoryContainsAndAreaContainsOrderByViewCountDesc(category, area);
             case starCount:
-                return postRepository.findByCategoryContainsOrderByStarCountDesc(category);
+                return postRepository.findByCategoryContainsAndAreaContainsOrderByStarCountDesc(category, area);
             default:
-                return postRepository.findByCategoryContainsOrderByIdAsc(category);
+                return postRepository.findByCategoryContainsAndAreaContainsOrderByIdAsc(category, area);
         }
 
     }


### PR DESCRIPTION
1. **필터 ( 카테고리만)**
중앙부처 + 지역(서울) -> 생활지원만 가져옴. 테스트 완료
2.  **필터(카테고리, 지역)**
지역(서울)이며, 생활지원 데이터 가져옴. 테스트 완료
3. **필터(카테고리, 정렬)**
카테고리에 맞는 중앙+지역 데이터 가져오며 ViewCount, StarCount 사용 가능. 테스트 완료
4. **필터( 카테고리,지역,정렬)**
카테고리, 지역, 정렬에 맞는 데이터 가져옴. 테스트 완료

![image](https://user-images.githubusercontent.com/70589857/132098723-af316b80-c8ef-470f-ae57-649df2942bbd.png)
![image](https://user-images.githubusercontent.com/70589857/132098725-b99a2df8-1508-48a6-8abd-a90366e6e9d7.png)
![image](https://user-images.githubusercontent.com/70589857/132098726-ee28fb3a-8ee1-4f71-a5a9-5fe776ac6718.png)
![image](https://user-images.githubusercontent.com/70589857/132098730-63599126-5b74-447c-adc8-ac2f1cbf5b8f.png)
