### PR TITLE
[fix:#26] 스크랩 예외처리 및 응답 방식 변경

### DIFF
--- a/src/main/java/bokzip/back/config/response/ErrorResponse.java
+++ b/src/main/java/bokzip/back/config/response/ErrorResponse.java
@@ -8,12 +8,19 @@ import lombok.Data;
 @AllArgsConstructor
 @Builder
 public class ErrorResponse<T> {
-    private String errorMessage;
+    private String message;
+    private Object data;
 
     // @param : Error Message를 전송할 때 사용
-    public static ErrorResponse res(final String errorMessage) {
+    public static ErrorResponse res(final String message) {
         return ErrorResponse.builder()
-                .errorMessage(errorMessage)
+                .message(message)
+                .build();
+    }
+    public static ErrorResponse res2(final String message, final Object data) {
+        return ErrorResponse.builder()
+                .message(message)
+                .data(data)
                 .build();
     }
 }

--- a/src/main/java/bokzip/back/config/response/SuccessResponse.java
+++ b/src/main/java/bokzip/back/config/response/SuccessResponse.java
@@ -1,19 +1,29 @@
 package bokzip.back.config.response;
 
+import bokzip.back.dto.ScrapMapping;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @Builder
 public class SuccessResponse<T> {
-    private String successMessage;
+    private final String message;
+    private final List<ScrapMapping> data;;
 
     // @param : Success Message를 전송할 때 사용 (스크랩 시 통일된 json 형태로 메세지 보내기 위함)
-    public static SuccessResponse res(final String successMessage) {
+    public static SuccessResponse res(final String message) {
         return SuccessResponse.builder()
-                .successMessage(successMessage)
+                .message(message)
+                .build();
+    }
+    public static SuccessResponse res(final String message, final List<ScrapMapping> data) {
+        return SuccessResponse.builder()
+                .message(message)
+                .data(data)
                 .build();
     }
 }

--- a/src/main/java/bokzip/back/controller/ScrapController.java
+++ b/src/main/java/bokzip/back/controller/ScrapController.java
@@ -47,8 +47,8 @@ public class ScrapController {
     }
 
     @GetMapping("")
-    public List<ScrapMapping> scraps() {
+    public ResponseEntity scraps() {
         List<ScrapMapping> scraps = scrapService.displayScraps();
-        return scraps;
+        return new ResponseEntity<>(SuccessResponse.res("스크랩 조회 성공했습니다.", scraps), HttpStatus.OK);
     }
 }


### PR DESCRIPTION
클라이언트 요청에 맞춰 스크랩 성공/실패의 경우 message / data 형식으로 보내도록 수정하였습니다!

슬랙에 보낸 것과 같이 스크랩 로그인 시 성공가능합니다의 경우 클라의 요청대로 data : null로 보여줘야 하지만,
이 외 다른 예외 상황에서도 data를 보여주지 않아도 될 상황에 data가 null로 보여지는 문제가 존재합니다
![image](https://user-images.githubusercontent.com/68772751/138999583-c5509f1a-8531-46de-b925-d39d21ea4726.png)

![image](https://user-images.githubusercontent.com/68772751/138999553-870ca4da-fee1-46b4-b62b-258f9a215c2c.png)
