### PR TITLE
[fix#6] 클라 요청에 따라 image -> thumbnail 로 변경함에 따라 return 값 변경

### DIFF
--- a/src/main/java/bokzip/back/dto/GeneralMapping.java
+++ b/src/main/java/bokzip/back/dto/GeneralMapping.java
@@ -4,6 +4,6 @@ public interface GeneralMapping {
     Long getId();
     String getCategory();
     String getTitle();
-    String getImage();
+    String getThumbnail();
     Boolean getIsScrap();
 }


### PR DESCRIPTION
general 데이터의 경우 db 칼럼 자체가 image로 되어있어서 heroku에 올라간 db에 칼럼을 image -> thumbnail로 변경하였습니다.

변경과 동시에 image를 단독으로 가져오는 경우는 없고, GeneralMapping()에서만 사용해서 get()함수를 변경하였습니다!